### PR TITLE
Fix/fixing grid to be finite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,3 @@
 name = "rust-game-of-life"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Conways Game of Life
-> but in a 2-sphere
 
-This project aims to implement Conway's Game of Life, but instead of being on an infinite plane, the game will take place on a 2-sphere. There is no particular reason for implementing this, it was just a fun idea I had to use as an excuse to learn the Rust language. 
+This project aims to implement Conway's Game of Life. There is no particular reason for implementing this, it was just a fun idea I had to use as an excuse to learn the Rust language. 
 
 > Nothing here is safe or efficient. This is a case study.
-
-# Some math background
-
-TODO...

--- a/src/domain/cell.rs
+++ b/src/domain/cell.rs
@@ -15,117 +15,68 @@ impl Cell {
     return Ok(Cell { x, y, size });
   }
 
-  pub fn get_left(&self) -> Cell {
-    let new_x: i16;
-
+  pub fn get_left(&self) -> Option<Cell> {
     if self.x == 0 {
-      new_x = self.size - 1;
-    } else {
-      new_x = self.x - 1;
+      return None;
     }
 
-    return Cell::new(new_x, self.y, self.size).unwrap();
+    return Some(Cell::new(self.x - 1, self.y, self.size).unwrap());
   }
 
-  pub fn get_right(&self) -> Cell {
-    let new_x: i16;
+  pub fn get_right(&self) -> Option<Cell> {
     if self.x == self.size - 1 {
-      new_x = 0;
-    } else {
-      new_x = self.x + 1;
+      return None;
     }
-    return Cell::new(new_x, self.y, self.size).unwrap();
+
+    return Some(Cell::new(self.x + 1, self.y, self.size).unwrap());
   }
 
-  pub fn get_top(&self) -> Cell {
-    let new_y: i16;
+  pub fn get_top(&self) -> Option<Cell> {
     if self.y == 0 {
-      new_y = self.size - 1;
-    } else {
-      new_y = self.y - 1;
+      return None;
     }
-    return Cell::new(self.x, new_y, self.size).unwrap();
+
+    return Some(Cell::new(self.x, self.y - 1, self.size).unwrap());
   }
 
-  pub fn get_bottom(&self) -> Cell {
-    let new_y: i16;
+  pub fn get_bottom(&self) -> Option<Cell> {
     if self.y == self.size - 1 {
-      new_y = 0;
-    } else {
-      new_y = self.y + 1;
+      return None;
     }
-    return Cell::new(self.x, new_y, self.size).unwrap();
+
+    return Some(Cell::new(self.x, self.y + 1, self.size).unwrap());
   }
 
-  pub fn get_upper_left(&self) -> Cell {
-    let new_x: i16;
-    let new_y: i16;
-
-    if self.x == 0 {
-      new_x = self.size - 1;
-    } else {
-      new_x = self.x - 1;
-    }
-    if self.y == 0 {
-      new_y = self.size - 1;
-    } else {
-      new_y = self.y - 1;
+  pub fn get_upper_left(&self) -> Option<Cell> {
+    if self.x == 0 || self.y == 0 {
+      return None;
     }
 
-    return Cell::new(new_x, new_y, self.size).unwrap();
+    return Some(Cell::new(self.x - 1, self.y - 1, self.size).unwrap());
   }
 
-  pub fn get_upper_right(&self) -> Cell {
-    let new_y: i16;
-    let new_x: i16;
-
-    if self.x == self.size - 1 {
-      new_x = 0;
-    } else {
-      new_x = self.x + 1;
-    }
-    if self.y == 0 {
-      new_y = self.size - 1;
-    } else {
-      new_y = self.y - 1;
+  pub fn get_upper_right(&self) -> Option<Cell> {
+    if self.x == self.size - 1 || self.y == 0 {
+      return None;
     }
 
-    return Cell::new(new_x, new_y, self.size).unwrap();
+    return Some(Cell::new(self.x + 1, self.y - 1, self.size).unwrap());
   }
 
-  pub fn get_bottom_left(&self) -> Cell {
-    let new_y: i16;
-    let new_x: i16;
-
-    if self.x == 0 {
-      new_x = self.size - 1;
-    } else {
-      new_x = self.x - 1;
-    }
-    if self.y == self.size - 1 {
-      new_y = 0;
-    } else {
-      new_y = self.y + 1;
+  pub fn get_bottom_left(&self) -> Option<Cell> {
+    if self.x == 0 || self.y == self.size - 1 {
+      return None;
     }
 
-    return Cell::new(new_x, new_y, self.size).unwrap();
+    return Some(Cell::new(self.x - 1, self.y + 1, self.size).unwrap());
   }
 
-  pub fn get_bottom_right(&self) -> Cell {
-    let new_y: i16;
-    let new_x: i16;
+  pub fn get_bottom_right(&self) -> Option<Cell> {
+    if self.x == self.size - 1 || self.y == self.size - 1 {
+      return None;
+    }
 
-    if self.x == self.size - 1 {
-      new_x = 0;
-    } else {
-      new_x = self.x + 1;
-    }
-    if self.y == self.size - 1 {
-      new_y = 0;
-    } else {
-      new_y = self.y + 1;
-    }
-    return Cell::new(new_x, new_y, self.size).unwrap();
+    return Some(Cell::new(self.x + 1, self.y + 1, self.size).unwrap());
   }
 }
 

--- a/src/domain/grid.rs
+++ b/src/domain/grid.rs
@@ -1,11 +1,11 @@
 use std::fmt;
-
 use super::{ cell::Cell, neighborhood::Neighborhood };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Grid {
   grid: Vec<Vec<bool>>,
   size: i16,
+  age: i64,
 }
 
 impl Grid {
@@ -13,6 +13,7 @@ impl Grid {
     Grid {
       grid: vec![vec![false; size as usize]; size as usize],
       size: size,
+      age: 0,
     }
   }
 
@@ -73,29 +74,39 @@ impl Grid {
       }
     }
 
-    self.update_many(to_mutate)
+    self.update_many(to_mutate);
+    self.age += 1;
   }
 
+  pub fn get_age(&self) -> i64 {
+    self.age
+  }
+
+  #[allow(dead_code)]
   pub fn get_grid(&self) -> &Vec<Vec<bool>> {
     &self.grid
   }
 }
 
 impl<'a> fmt::Display for Grid {
+  // Temporary apresentation of the grid just for testing purposes
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let mut grid_string = String::new();
+    let mut grid_string = String::from("# ").repeat((self.size as usize) + 3);
+    grid_string.push_str("\n#  ");
 
     for row in &self.grid {
       for cell in row {
         if *cell {
-          grid_string.push_str("1 ");
+          grid_string.push_str("\x1b[94m\u{23F9} \x1b[94m");
         } else {
-          grid_string.push_str("0 ");
+          grid_string.push_str("\x1b[93m\u{23F9} \x1b[0m");
         }
       }
-      grid_string.push_str("\n");
+      grid_string.push_str("  #\n#  ");
     }
 
+    let end = String::from("# ").repeat((self.size as usize) + 2);
+    grid_string.push_str(&end);
     write!(f, "{}", grid_string)
   }
 }

--- a/src/domain/neighborhood.rs
+++ b/src/domain/neighborhood.rs
@@ -56,14 +56,6 @@ fn _parse(cell: Option<Cell>) -> String {
 
 impl fmt::Display for Neighborhood {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let left = match self.left {
-      Some(ref x) => format!("{}", x),
-      None => String::from("None"),
-    };
-    let top = match self.top {
-      Some(ref x) => format!("{}", x),
-      None => String::from("None"),
-    };
     write!(
       f,
       "{} {} {}\n {} X:X {}\n {} {} {}",

--- a/src/domain/neighborhood.rs
+++ b/src/domain/neighborhood.rs
@@ -4,14 +4,14 @@ use super::cell::Cell;
 
 #[derive(Debug)]
 pub struct Neighborhood {
-  pub left: Cell,
-  pub right: Cell,
-  pub top: Cell,
-  pub bottom: Cell,
-  pub upper_left: Cell,
-  pub upper_right: Cell,
-  pub bottom_left: Cell,
-  pub bottom_right: Cell,
+  pub left: Option<Cell>,
+  pub right: Option<Cell>,
+  pub top: Option<Cell>,
+  pub bottom: Option<Cell>,
+  pub upper_left: Option<Cell>,
+  pub upper_right: Option<Cell>,
+  pub bottom_left: Option<Cell>,
+  pub bottom_right: Option<Cell>,
 }
 
 impl Neighborhood {
@@ -29,7 +29,7 @@ impl Neighborhood {
   }
 
   pub fn iter(&self) -> Vec<Cell> {
-    vec![
+    let mut _vec = vec![
       self.upper_left,
       self.top,
       self.upper_right,
@@ -38,31 +38,43 @@ impl Neighborhood {
       self.bottom_left,
       self.bottom,
       self.bottom_right
-    ]
+    ];
+    return _vec
+      .iter()
+      .filter(|&x| x.is_some())
+      .map(|x| x.unwrap())
+      .collect();
   }
+}
+
+fn _parse(cell: Option<Cell>) -> String {
+  return match cell {
+    Some(x) => format!("{}", x),
+    None => String::from("None"),
+  };
 }
 
 impl fmt::Display for Neighborhood {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let left = match self.left {
+      Some(ref x) => format!("{}", x),
+      None => String::from("None"),
+    };
+    let top = match self.top {
+      Some(ref x) => format!("{}", x),
+      None => String::from("None"),
+    };
     write!(
       f,
-      "{}:{} {}:{} {}:{}\n {}:{} X:X {}:{}\n {}:{} {}:{} {}:{}",
-      self.upper_left.x,
-      self.upper_left.y,
-      self.top.x,
-      self.top.y,
-      self.upper_right.x,
-      self.upper_right.y,
-      self.left.x,
-      self.left.y,
-      self.right.x,
-      self.right.y,
-      self.bottom_left.x,
-      self.bottom_left.y,
-      self.bottom.x,
-      self.bottom.y,
-      self.bottom_right.x,
-      self.bottom_right.y
+      "{} {} {}\n {} X:X {}\n {} {} {}",
+      _parse(self.left),
+      _parse(self.top),
+      _parse(self.upper_right),
+      _parse(self.left),
+      _parse(self.right),
+      _parse(self.bottom_left),
+      _parse(self.bottom),
+      _parse(self.bottom_right)
     )
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,30 @@
 mod domain;
 mod tests;
 
+use std::thread::sleep;
+use std::time::Duration;
+
+use domain::grid::Grid;
+use domain::cell::Cell;
+
 fn main() {
-  println!("Hello, world!");
+  const GRID_SIZE: i16 = 20;
+  const FPS: i16 = 1;
+
+  let mut grid = Grid::new(GRID_SIZE);
+  grid.update_field(Cell::new(10, 10, GRID_SIZE).unwrap());
+  grid.update_field(Cell::new(10, 11, GRID_SIZE).unwrap());
+  grid.update_field(Cell::new(10, 12, GRID_SIZE).unwrap());
+  grid.update_field(Cell::new(11, 11, GRID_SIZE).unwrap());
+
+  print!("{esc}c", esc = 27 as char);
+  println!("{}", grid);
+  grid.mutate();
+  loop {
+    sleep(Duration::from_millis(1000 / (FPS as u64)));
+    print!("{esc}c", esc = 27 as char);
+    println!("Generation: {}", grid.get_age());
+    println!("{}", grid);
+    grid.mutate();
+  }
 }

--- a/src/tests/domain/grid/test_grid.rs
+++ b/src/tests/domain/grid/test_grid.rs
@@ -70,9 +70,9 @@ fn test_grid_mutate_2() {
 #[test]
 fn test_grid_mutate_3() {
   // Before: 0 0 0 0 0  After: 0 0 0 0 0
-  //         0 0 0 0 0         1 0 0 0 0
-  //         1 1 0 0 1         1 0 0 0 0
-  //         0 0 0 0 0         1 0 0 0 0
+  //         0 0 0 0 0         0 0 0 0 0
+  //         1 1 0 0 1         0 0 0 0 0
+  //         0 0 0 0 0         0 0 0 0 0
   //         0 0 0 0 0         0 0 0 0 0
 
   let mut grid = Grid::new(5);
@@ -86,10 +86,9 @@ fn test_grid_mutate_3() {
 
   grid.mutate();
 
-  assert!(grid.get_grid()[0][1]);
-  assert!(grid.get_grid()[0][2]);
-  assert!(grid.get_grid()[0][3]);
-
+  assert_eq!(grid.get_grid()[0][1], false);
+  assert_eq!(grid.get_grid()[0][2], false);
+  assert_eq!(grid.get_grid()[0][3], false);
   assert_eq!(grid.get_grid()[1][2], false);
   assert_eq!(grid.get_grid()[4][2], false);
 }

--- a/src/tests/domain/test_cell.rs
+++ b/src/tests/domain/test_cell.rs
@@ -28,7 +28,7 @@ fn test_cell_display() {
 #[test]
 fn test_get_left() {
   let cell = Cell::new(1, 0, GRID_SIZE).unwrap();
-  let left = cell.get_left();
+  let left = cell.get_left().unwrap();
 
   assert_eq!(left.x, 0);
   assert_eq!(left.y, 0);
@@ -39,14 +39,13 @@ fn test_get_left_bigger_than_grid_size() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
   let left = cell.get_left();
 
-  assert_eq!(left.x, GRID_SIZE - 1);
-  assert_eq!(left.y, cell.y);
+  assert!(left.is_none());
 }
 
 #[test]
 fn test_get_right() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
-  let right = cell.get_right();
+  let right = cell.get_right().unwrap();
 
   assert_eq!(right.x, 1);
   assert_eq!(right.y, 0);
@@ -57,14 +56,13 @@ fn test_get_right_bigger_than_grid_size() {
   let cell = Cell::new(GRID_SIZE - 1, 0, GRID_SIZE).unwrap();
   let right = cell.get_right();
 
-  assert_eq!(right.x, 0);
-  assert_eq!(right.y, cell.y);
+  assert_eq!(right.is_some(), false);
 }
 
 #[test]
 fn test_get_top() {
   let cell = Cell::new(0, 1, GRID_SIZE).unwrap();
-  let top = cell.get_top();
+  let top = cell.get_top().unwrap();
 
   assert_eq!(top.x, 0);
   assert_eq!(top.y, 0);
@@ -75,14 +73,13 @@ fn test_get_top_bigger_than_grid_size() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
   let top = cell.get_top();
 
-  assert_eq!(top.x, cell.x);
-  assert_eq!(top.y, GRID_SIZE - 1);
+  assert_eq!(top.is_some(), false);
 }
 
 #[test]
 fn test_get_bottom() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
-  let bottom = cell.get_bottom();
+  let bottom = cell.get_bottom().unwrap();
 
   assert_eq!(bottom.x, 0);
   assert_eq!(bottom.y, 1);
@@ -93,14 +90,13 @@ fn test_get_bottom_bigger_than_grid_size() {
   let cell = Cell::new(0, GRID_SIZE - 1, GRID_SIZE).unwrap();
   let bottom = cell.get_bottom();
 
-  assert_eq!(bottom.x, cell.x);
-  assert_eq!(bottom.y, 0);
+  assert_eq!(bottom.is_some(), false);
 }
 
 #[test]
 fn test_get_upper_left() {
   let cell = Cell::new(1, 1, GRID_SIZE).unwrap();
-  let upper_left = cell.get_upper_left();
+  let upper_left = cell.get_upper_left().unwrap();
 
   assert_eq!(upper_left.x, 0);
   assert_eq!(upper_left.y, 0);
@@ -111,14 +107,13 @@ fn test_get_upper_left_bigger_than_grid_size() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
   let upper_left = cell.get_upper_left();
 
-  assert_eq!(upper_left.x, GRID_SIZE - 1);
-  assert_eq!(upper_left.y, GRID_SIZE - 1);
+  assert_eq!(upper_left.is_some(), false);
 }
 
 #[test]
 fn test_get_upper_right() {
   let cell = Cell::new(0, 1, GRID_SIZE).unwrap();
-  let upper_right = cell.get_upper_right();
+  let upper_right = cell.get_upper_right().unwrap();
 
   assert_eq!(upper_right.x, 1);
   assert_eq!(upper_right.y, 0);
@@ -129,14 +124,13 @@ fn test_get_upper_right_bigger_than_grid_size() {
   let cell = Cell::new(GRID_SIZE - 1, 0, GRID_SIZE).unwrap();
   let upper_right = cell.get_upper_right();
 
-  assert_eq!(upper_right.x, 0);
-  assert_eq!(upper_right.y, GRID_SIZE - 1);
+  assert_eq!(upper_right.is_some(), false);
 }
 
 #[test]
 fn test_get_bottom_left() {
   let cell = Cell::new(1, 0, GRID_SIZE).unwrap();
-  let bottom_left = cell.get_bottom_left();
+  let bottom_left = cell.get_bottom_left().unwrap();
 
   assert_eq!(bottom_left.x, 0);
   assert_eq!(bottom_left.y, 1);
@@ -147,14 +141,13 @@ fn test_get_bottom_left_bigger_than_grid_size() {
   let cell = Cell::new(0, GRID_SIZE - 1, GRID_SIZE).unwrap();
   let bottom_left = cell.get_bottom_left();
 
-  assert_eq!(bottom_left.x, GRID_SIZE - 1);
-  assert_eq!(bottom_left.y, 0);
+  assert_eq!(bottom_left.is_some(), false);
 }
 
 #[test]
 fn test_get_bottom_right() {
   let cell = Cell::new(0, 0, GRID_SIZE).unwrap();
-  let bottom_right = cell.get_bottom_right();
+  let bottom_right = cell.get_bottom_right().unwrap();
 
   assert_eq!(bottom_right.x, 1);
   assert_eq!(bottom_right.y, 1);
@@ -165,6 +158,5 @@ fn test_get_bottom_right_bigger_than_grid_size() {
   let cell = Cell::new(GRID_SIZE - 1, GRID_SIZE - 1, GRID_SIZE).unwrap();
   let bottom_right = cell.get_bottom_right();
 
-  assert_eq!(bottom_right.x, 0);
-  assert_eq!(bottom_right.y, 0);
+  assert_eq!(bottom_right.is_some(), false);
 }

--- a/src/tests/domain/test_neighborhood.rs
+++ b/src/tests/domain/test_neighborhood.rs
@@ -3,25 +3,10 @@ use crate::domain::{ neighborhood::Neighborhood, cell::Cell };
 
 #[test]
 fn test_new_neighborhood() {
-  let cell = Cell::new(0, 0, 10).unwrap();
+  let cell = Cell::new(5, 5, 10).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.left.x, 9);
-  assert_eq!(neighborhood.left.y, 0);
-  assert_eq!(neighborhood.right.x, 1);
-  assert_eq!(neighborhood.right.y, 0);
-  assert_eq!(neighborhood.top.x, 0);
-  assert_eq!(neighborhood.top.y, 9);
-  assert_eq!(neighborhood.bottom.x, 0);
-  assert_eq!(neighborhood.bottom.y, 1);
-  assert_eq!(neighborhood.upper_left.x, 9);
-  assert_eq!(neighborhood.upper_left.y, 9);
-  assert_eq!(neighborhood.upper_right.x, 1);
-  assert_eq!(neighborhood.upper_right.y, 9);
-  assert_eq!(neighborhood.bottom_left.x, 9);
-  assert_eq!(neighborhood.bottom_left.y, 1);
-  assert_eq!(neighborhood.bottom_right.x, 1);
-  assert_eq!(neighborhood.bottom_right.y, 1);
+  assert_eq!(neighborhood.iter().len(), 8);
 }
 
 #[test]
@@ -29,47 +14,7 @@ fn test_new_neighborhood_bigger_than_grid_size() {
   let cell = Cell::new(9, 9, 10).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.left.x, 8);
-  assert_eq!(neighborhood.left.y, 9);
-  assert_eq!(neighborhood.right.x, 0);
-  assert_eq!(neighborhood.right.y, 9);
-  assert_eq!(neighborhood.top.x, 9);
-  assert_eq!(neighborhood.top.y, 8);
-  assert_eq!(neighborhood.bottom.x, 9);
-  assert_eq!(neighborhood.bottom.y, 0);
-  assert_eq!(neighborhood.upper_left.x, 8);
-  assert_eq!(neighborhood.upper_left.y, 8);
-  assert_eq!(neighborhood.upper_right.x, 0);
-  assert_eq!(neighborhood.upper_right.y, 8);
-  assert_eq!(neighborhood.bottom_left.x, 8);
-  assert_eq!(neighborhood.bottom_left.y, 0);
-  assert_eq!(neighborhood.bottom_right.x, 0);
-  assert_eq!(neighborhood.bottom_right.y, 0);
-}
-
-#[test]
-fn test_neighborhood_iter() {
-  let cell = Cell::new(0, 0, 10).unwrap();
-  let neighborhood = Neighborhood::new(&cell);
-  let iter = neighborhood.iter();
-
-  assert_eq!(iter.len(), 8);
-  assert_eq!(iter[0].x, 9);
-  assert_eq!(iter[0].y, 9);
-  assert_eq!(iter[1].x, 0);
-  assert_eq!(iter[1].y, 9);
-  assert_eq!(iter[2].x, 1);
-  assert_eq!(iter[2].y, 9);
-  assert_eq!(iter[3].x, 9);
-  assert_eq!(iter[3].y, 0);
-  assert_eq!(iter[4].x, 1);
-  assert_eq!(iter[4].y, 0);
-  assert_eq!(iter[5].x, 9);
-  assert_eq!(iter[5].y, 1);
-  assert_eq!(iter[6].x, 0);
-  assert_eq!(iter[6].y, 1);
-  assert_eq!(iter[7].x, 1);
-  assert_eq!(iter[7].y, 1);
+  assert_eq!(neighborhood.iter().len(), 3);
 }
 
 #[test]
@@ -77,9 +22,7 @@ fn test_neighborhood_zero_x_index() {
   let cell = Cell::new(0, 2, 5).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.left.x, 4);
-  assert_eq!(neighborhood.upper_left.x, 4);
-  assert_eq!(neighborhood.bottom_left.x, 4);
+  assert_eq!(neighborhood.iter().len(), 5);
 }
 
 #[test]
@@ -87,9 +30,7 @@ fn test_neighborhood_zero_y_index() {
   let cell = Cell::new(2, 0, 5).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.top.y, 4);
-  assert_eq!(neighborhood.upper_right.y, 4);
-  assert_eq!(neighborhood.upper_right.y, 4);
+  assert_eq!(neighborhood.iter().len(), 5);
 }
 
 #[test]
@@ -97,9 +38,7 @@ fn test_neighborhood_max_x_index() {
   let cell = Cell::new(4, 2, 5).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.right.x, 0);
-  assert_eq!(neighborhood.upper_right.x, 0);
-  assert_eq!(neighborhood.bottom_right.x, 0);
+  assert_eq!(neighborhood.iter().len(), 5);
 }
 
 #[test]
@@ -107,9 +46,7 @@ fn test_neighborhood_max_y_index() {
   let cell = Cell::new(2, 4, 5).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.bottom.y, 0);
-  assert_eq!(neighborhood.bottom_left.y, 0);
-  assert_eq!(neighborhood.bottom_right.y, 0);
+  assert_eq!(neighborhood.iter().len(), 5);
 }
 
 #[test]
@@ -117,8 +54,5 @@ fn test_neighborhood_origin() {
   let cell = Cell::new(0, 0, 5).unwrap();
   let neighborhood = Neighborhood::new(&cell);
 
-  assert_eq!(neighborhood.top.x, 0);
-  assert_eq!(neighborhood.top.y, 4);
-  assert_eq!(neighborhood.upper_left.x, 4);
-  assert_eq!(neighborhood.upper_right.y, 4);
+  assert_eq!(neighborhood.iter().len(), 3);
 }


### PR DESCRIPTION
# Problem description

1. Reverting temporarily the idea of a game of life in a 2sphere
2. Have a way to run the game in a simple way in terminal

# Adopted solution

1. `Neighborhood` and `Cell` implementation was refactored. No, cells "outside" the grid are considered dead, cells cant spread to locations outside the grid.
* 1.1.  There is an idea to do a fixed size matrix and every time the game consult an nonexistent cell, the game would increase the matrix size, so its will be "infinite".
2. `Grid::Display` was improved to play the game using `println!`
* 2.1. Simple run of the game was done in `main.rs`

...